### PR TITLE
Make sure that users disable k8s-ces-control if they disable monitoring

### DIFF
--- a/docs/operations/configuration_de.md
+++ b/docs/operations/configuration_de.md
@@ -100,7 +100,8 @@ backup:
 
 ## Monitoring-Komponenten (`monitoring`)
 
-Aktiviert und verwaltet den **Monitoring-Stacks** und dessen Komponenten.
+Aktiviert und verwaltet den **Monitoring-Stack** und dessen Komponenten.
+Achtung: Wenn der Monitoring-Stack deaktiviert wird, muss auch die k8s-ces-control-Komponente deaktiviert werden!
 
 ```yaml
 monitoring:

--- a/docs/operations/configuration_en.md
+++ b/docs/operations/configuration_en.md
@@ -102,6 +102,7 @@ backup:
 ## Monitoring components (`monitoring`)
 
 Enables and manages the **monitoring stack** and its components.
+Warning: If you disable the monitoring stack you also have to disable the k8s-ces-control component!
 
 ```yaml
 monitoring:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -56,6 +56,7 @@ backup:
     k8s-velero:
       version: 11.4.0-2
 monitoring:
+  # Make sure to disable the k8s-ces-control component if you disable the monitoring stack!
   enabled: true
   components:
     k8s-prometheus:


### PR DESCRIPTION
As k8s-ces-control needs k8s-loki to start at the moment, you will get a failing k8s-ces-control component in your cluster if you disable the monitoring stack.