### PR TITLE
README: Add hint on helm template

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ It works standalone or via GitOps tools like [Argo CD](https://argoproj.github.i
 ## Validations / preconditions
 
 The "Component" CustomResourceDefinition (CRD) must be installed first in the cluster.
-This is required by the `k8s-component-operator` to manage component objects.
+This is required by the `k8s-component-operator` to manage component objects.  
+If you want to run `helm template`, you'll have to add this API like so:  
+`helm template --api-versions k8s.cloudogu.com/v1/Component ...`.  
+Note that this is not necessary on Argo CD, if you install the CRDs first, see [docs/argoCD](docs/operations/argoCD_en.md) - `argocd.argoproj.io/sync-wave: "-1"`)
 
 This chart can fail fast when required Secrets/ConfigMaps are missing. We use Helm’s `lookup` during install to 
 verify they exist and (optionally) contain specific keys. 


### PR DESCRIPTION
`helm template oci://registry.cloudogu.com/k8s/ecosystem-core` fails with
`Error: execution error at (ecosystem-core/templates/00-validate-preconditions.yaml:2:6): CRD k8s.cloudogu.com/v1/Component is not installed.`

Which is an unpleasant surprise.

...which seems difficult to fix. 
In helm we seem not to be able to detect `template`. We can check i`if .Release.IsDryRun` but in dry run (with a live cluster) we actually want to validate. We can also not rely on `if or .Release.IsInstall .Release.IsUpgrade`  because `template` seems to set these as well 🙄

So I actually did no change anything, just doc how to do a template if anyone ever wanted to do that.