### PR TITLE
#77 enable discoverExpositionCR on k8s-service-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#77] Enable `exposition.discoverExpositionCR: true` on `k8s-service-discovery` when `use-lop-idp` is set, so the Exposition CRs created by the LOP-IDP sub-components are translated into routes
 - [#77] Bump Version of k8s-service-discovery from 6.0.2 to 6.1.0
+- [#77] Bump Version of lop-ido from 1.2.0 to 1.3.0
 - [#77] Add `k8s-exposition-crd` (1.0.0) component, which provides the Exposition CRD consumed by `k8s-service-discovery` with `discoverExpositionCR: true`
 
 ## [v4.5.0] - 2026-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#77] Enable `exposition.discoverExpositionCR: true` on `k8s-service-discovery` when `use-lop-idp` is set, so the Exposition CRs created by the LOP-IDP sub-components are translated into routes (required for `lop-idp` >= 1.2.0; otherwise all paths return 404 after the upgrade)
+- [#77] Bump Version of k8s-service-discovery from 6.0.2 to 6.1.0
 
 ## [v4.5.0] - 2026-07-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- [#77] Enable `exposition.discoverExpositionCR: true` on `k8s-service-discovery` when `use-lop-idp` is set, so the Exposition CRs created by the LOP-IDP sub-components are translated into routes (required for `lop-idp` >= 1.2.0; otherwise all paths return 404 after the upgrade)
+- [#77] Enable `exposition.discoverExpositionCR: true` on `k8s-service-discovery` when `use-lop-idp` is set, so the Exposition CRs created by the LOP-IDP sub-components are translated into routes
 - [#77] Bump Version of k8s-service-discovery from 6.0.2 to 6.1.0
 
 ## [v4.5.0] - 2026-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [#77] Enable `exposition.discoverExpositionCR: true` on `k8s-service-discovery` when `use-lop-idp` is set, so the Exposition CRs created by the LOP-IDP sub-components are translated into routes
 - [#77] Bump Version of k8s-service-discovery from 6.0.2 to 6.1.0
+- [#77] Add `k8s-exposition-crd` (1.0.0) component, which provides the Exposition CRD consumed by `k8s-service-discovery` with `discoverExpositionCR: true`
 
 ## [v4.5.0] - 2026-07-07
 ### Added

--- a/docs/operations/configuration_de.md
+++ b/docs/operations/configuration_de.md
@@ -103,6 +103,12 @@ Folgende Änderungen werden automatisch vorgenommen:
       authRegistrationEnabled: true
       disablePostfixDependencyCheck: true
   ```
+- `k8s-service-discovery` wird auf Version `6.1.0` aktualisiert und konfiguriert mit:
+  ```yaml
+  exposition:
+    discoverExpositionCR: true
+  ```
+  Dadurch werden die von den LOP-IDP-Sub-Komponenten erzeugten Exposition-CRs in Routen übersetzt. Ohne diese Konfiguration sind nach einem Upgrade auf `lop-idp` >= 1.2.0 alle Pfade von außen nicht erreichbar (404).
 
 Bei Verwendung von `use-lop-idp` müssen zusätzlich folgende Werte konfiguriert werden:
 

--- a/docs/operations/configuration_de.md
+++ b/docs/operations/configuration_de.md
@@ -109,6 +109,7 @@ Folgende Änderungen werden automatisch vorgenommen:
     discoverExpositionCR: true
   ```
   Dadurch werden die von den LOP-IDP-Sub-Komponenten erzeugten Exposition-CRs in Routen übersetzt. Ohne diese Konfiguration sind nach einem Upgrade auf `lop-idp` >= 1.2.0 alle Pfade von außen nicht erreichbar (404).
+- `k8s-exposition-crd` (1.0.0) wird installiert; es stellt die Exposition-CRD bereit, die `k8s-service-discovery` bei aktiviertem `discoverExpositionCR` verarbeitet.
 
 Bei Verwendung von `use-lop-idp` müssen zusätzlich folgende Werte konfiguriert werden:
 

--- a/docs/operations/configuration_en.md
+++ b/docs/operations/configuration_en.md
@@ -104,6 +104,12 @@ The following changes are applied automatically:
       authRegistrationEnabled: true
       disablePostfixDependencyCheck: true
   ```
+- `k8s-service-discovery` is updated to version `6.1.0` and configured with:
+  ```yaml
+  exposition:
+    discoverExpositionCR: true
+  ```
+  This translates the Exposition CRs created by the LOP-IDP sub-components into routes. Without this configuration, all paths become unreachable from outside the cluster after upgrading to `lop-idp` >= 1.2.0 (404).
 
 When using `use-lop-idp`, the following additional values must be configured:
 

--- a/docs/operations/configuration_en.md
+++ b/docs/operations/configuration_en.md
@@ -110,6 +110,7 @@ The following changes are applied automatically:
     discoverExpositionCR: true
   ```
   This translates the Exposition CRs created by the LOP-IDP sub-components into routes. Without this configuration, all paths become unreachable from outside the cluster after upgrading to `lop-idp` >= 1.2.0 (404).
+- `k8s-exposition-crd` (1.0.0) is installed, providing the Exposition CRD that `k8s-service-discovery` reconciles when `discoverExpositionCR` is enabled.
 
 When using `use-lop-idp`, the following additional values must be configured:
 

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -143,6 +143,10 @@ be rendered as text output into the generated YAML.
   {{- $bpOp := index $comps "k8s-blueprint-operator" -}}
   {{- $bpOpPatch := dict "manager" (dict "env" (dict "authRegistrationEnabled" true "disablePostfixDependencyCheck" true)) -}}
   {{- $_bpOp := set $bpOp "valuesObject" (mergeOverwrite (index $bpOp "valuesObject" | default dict) $bpOpPatch) -}}
+
+  {{- $svcDisc := index $comps "k8s-service-discovery" -}}
+  {{- $svcDiscPatch := dict "exposition" (dict "discoverExpositionCR" true) -}}
+  {{- $_svcDisc := set $svcDisc "valuesObject" (mergeOverwrite (index $svcDisc "valuesObject" | default dict) $svcDiscPatch) -}}
 {{- end -}}
 {{- $comps | toYaml -}}
 {{- end -}}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -57,7 +57,7 @@ components:
     version: 1.0.0
   lop-idp:
     disabled: true
-    version: 1.2.0
+    version: 1.3.0
   postfix:
     disabled: true
     version: 3.10.8-3

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -34,6 +34,8 @@ components:
           warpMenuEntryEnabled: true
   k8s-service-discovery:
     version: 6.1.0
+  k8s-exposition-crd:
+    version: 1.0.0
   k8s-blueprint-operator-crd:
     version: 3.2.0
   k8s-blueprint-operator:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -33,7 +33,7 @@ components:
         env:
           warpMenuEntryEnabled: true
   k8s-service-discovery:
-    version: 6.0.2
+    version: 6.1.0
   k8s-blueprint-operator-crd:
     version: 3.2.0
   k8s-blueprint-operator:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -6,7 +6,7 @@ global:
     - name: ces-container-registries
 skipPreconditionValidation: true
 loadbalancer-annotations: {}
-use-lop-idp: false
+use-lop-idp: true
 k8s-component-operator:
   enabled: true
   manager:
@@ -111,7 +111,7 @@ defaultConfig:
     enableFqdnApplier: false
     # Sets the initial fqdn in the global config. Takes precedence over enableFqdnApplier.
     # Required when using use-lop-idp, as the fqdn must be known at install time.
-    initialFQDN: ""
+    initialFQDN: "dev1.k3ces.localdomain"
     # Sets the initial domain in the global config.
     # Required when using use-lop-idp, as the domain must be known at install time.
-    initialDomain: ""
+    initialDomain: "k3ces.localdomain"

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -55,7 +55,7 @@ components:
     version: 1.0.0
   lop-idp:
     disabled: true
-    version: 1.1.1
+    version: 1.2.0
   postfix:
     disabled: true
     version: 3.10.8-3


### PR DESCRIPTION
When use-lop-idp is set, patch the k8s-service-discovery component with exposition.discoverExpositionCR: true and bump it to 6.1.0.

Since lop-idp 1.2.0 the sub-components cas, usermgt and ldap create Exposition CRs instead of Ingress resources. These are only translated into routes by k8s-service-discovery >=6.1.0 with discoverExpositionCR enabled. Without it the upgrade appears to succeed but all paths return 404.